### PR TITLE
Remove spurious repr() in getclsid()

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -2087,7 +2087,7 @@ class OleFileIO:
         """
         sid = self._find(filename)
         entry = self.direntries[sid]
-        return repr(entry.clsid)
+        return entry.clsid
 
 
     def getmtime(self, filename):


### PR DESCRIPTION
Remove a spurious repr() that sneaked into #46 that should not have been there in the first place.