### PR TITLE
olefile is a pure python library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = True


### PR DESCRIPTION
This'll produce py2.py3-none-any wheels when built with `pip wheel`.  I didn't see any custom py2 / py3 setup code so this should be correct?