### PR TITLE
Test on Windows CI with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+build: off
+environment:
+  matrix:
+    - PYTHON: "C:/Python27-x64"
+    - PYTHON: "C:/Python27"
+    - PYTHON: "C:/Python36-x64"
+    - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python35-x64"
+    - PYTHON: "C:/Python35"
+    - PYTHON: "C:/Python34-x64"
+    - PYTHON: "C:/Python34"
+    - PYTHON: "C:/Python33-x64"
+    - PYTHON: "C:/Python33"
+init:
+  - "ECHO %PYTHON%"
+  - ps: "ls C:/Python*"
+install:
+  - "%PYTHON%/python.exe -m pip install -U pip setuptools"
+  - "%PYTHON%/Scripts/pip.exe install coverage"
+  - "%PYTHON%/Scripts/pip.exe install nose"
+
+test_script:
+  - "%PYTHON%/Scripts/coverage.exe run --source=olefile -m nose tests"
+
+on_success:
+  - echo Build succesful!
+  - "%PYTHON%/Scripts/coverage.exe report"


### PR DESCRIPTION
Here's the config to run the unit tests on a Windows CI, based on .travis.yml.

Please go to https://ci.appveyor.com/projects/new to add the decalage2/olefile repo, it's free for open source.

I've added the 32-bit and 64-bit versions of the main Python versions. I've left out 2.6 and 3.2 for now, because they'll need a bit of special handling to install unittest2 and coverage<4 respectively.

See https://ci.appveyor.com/project/hugovk/olefile/build/1.0.5 for an example build.