### PR TITLE
Add fix to ignore incorrect ByteOrder

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -93,7 +93,7 @@ __author__  = "Philippe Lagadec"
 __all__ = ['isOleFile', 'OleFileIO', 'OleMetadata', 'enable_logging',
            'MAGIC', 'STGTY_EMPTY',
            'STGTY_STREAM', 'STGTY_STORAGE', 'STGTY_ROOT', 'STGTY_PROPERTY',
-           'STGTY_LOCKBYTES', 'MINIMAL_OLEFILE_SIZE',]
+           'STGTY_LOCKBYTES', 'MINIMAL_OLEFILE_SIZE', 'NOSTREAM']
 
 import io
 import sys
@@ -1202,7 +1202,7 @@ class OleFileIO:
         log.debug( "Byte Order    = %X (expected: FFFE)" % self.byte_order )
         if self.byte_order != 0xFFFE:
             # For now only common little-endian documents are handled correctly
-            self._raise_defect(DEFECT_FATAL, "incorrect ByteOrder in OLE header")
+            self._raise_defect(DEFECT_INCORRECT, "incorrect ByteOrder in OLE header")
             # TODO: add big-endian support for documents created on Mac ?
             # But according to [MS-CFB] ? v20140502, ByteOrder MUST be 0xFFFE.
         self.sector_size = 2**self.sector_shift


### PR DESCRIPTION
This will add the fix which is currently added in oletools, to ignore incorrect ByteOrder issues
https://github.com/decalage2/oletools/commit/433f234ff872a59fb6af5c10f9c4876a8c7002d0