### PR TITLE
Specify universal wheel as "universal = 1" as documneted

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = True
+universal = 1


### PR DESCRIPTION
Instead of "True", use 1. From the Wheel documentation:

https://wheel.readthedocs.io/en/stable/index.html

> Typically, projects would not specify Python tags on the command line, but would use setup.cfg to set them as a project default:
>
> ```
> [bdist_wheel]
> universal = 1
> ```