### PR TITLE
Explicitly declare the README encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ name         = "olefile"
 version      = __version__
 desc         = "Python package to parse, read and write Microsoft OLE2 files (Structured Storage or Compound Document, Microsoft Office) - Improved version of the OleFileIO module from PIL, the Python Image Library."
 # read long description from disk in restructuredtext format:
-long_desc    = open('README.rst').read()
+long_desc    = open('README.rst', encoding='utf-8').read()
 author       = __author__
 author_email = "https://www.decalage.info/contact"
 url          = "https://www.decalage.info/python/olefileio"


### PR DESCRIPTION
The default encoding used by `open` is system-dependent, and defaults to ASCII in many cases. Declaring the encoding explicitly prevents any issue from occurring.