### PR TITLE
Fix TypeError: 'float' object cannot be interpreted as an integer.

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -2131,7 +2131,7 @@ class OleFileIO:
             return data
 
         # clamp num_props based on the data length
-        num_props = min(num_props, len(s) / 8)
+        num_props = min(num_props, int(len(s) / 8))
 
         for i in iterrange(num_props):
             property_id = 0 # just in case of an exception


### PR DESCRIPTION
Both `range()` and `xrange()` expects integer as parameter, not float.

num_props is set to the second argument of min() when data length / 8 is lesser
than num_props, what is float, not int.

>>> 16/8
2.0