### PR TITLE
Add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
  - 3.4
  - 3.5
  - 3.6
+ - 3.7-dev
 
 # Use container-based infrastructure
 sudo: false

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ classifiers=[
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules"


### PR DESCRIPTION
Python 3.7 is in beta, so start testing it. The next quarterly Pillow release will support it. 

Currently `3.7-dev` is the latest on Travis CI, this can be switched when `3.7` is available. [AppVeyor](https://www.appveyor.com/docs/build-environment/#python) doesn't yet have it.

https://www.python.org/dev/peps/pep-0537/#schedule