### PR TITLE
Add context manager to OleFileIO

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -1022,7 +1022,6 @@ class OleFileIO:
             Unicode by default on Python 3+, UTF-8 on Python 2.x.
             (new in olefile 0.42, was hardcoded to Latin-1 until olefile v0.41)
         """
-        self.filename = filename
         # minimal level for defects to be raised as exceptions:
         self._raise_defects_level = raise_defects
         #: list of defects/issues not raised as exceptions:

--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -1073,7 +1073,8 @@ class OleFileIO:
 
 
     def __enter__(self):
-        return self.open(self.filename, write_mode=self.write_mode)
+        self.open(self.filename, write_mode=self.write_mode)
+        return self
 
 
     def __exit__(self, *args):

--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -1022,6 +1022,7 @@ class OleFileIO:
             Unicode by default on Python 3+, UTF-8 on Python 2.x.
             (new in olefile 0.42, was hardcoded to Latin-1 until olefile v0.41)
         """
+        self.filename = filename
         # minimal level for defects to be raised as exceptions:
         self._raise_defects_level = raise_defects
         #: list of defects/issues not raised as exceptions:
@@ -1069,6 +1070,14 @@ class OleFileIO:
         self.transaction_signature_number = None
         if filename:
             self.open(filename, write_mode=write_mode)
+
+
+    def __enter__(self):
+        return self.open(self.filename, write_mode=self.write_mode)
+
+
+    def __exit__(self, *args):
+        self.close()
 
 
     def _raise_defect(self, defect_level, message, exception_type=IOError):

--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -1073,7 +1073,6 @@ class OleFileIO:
 
 
     def __enter__(self):
-        self.open(self.filename, write_mode=self.write_mode)
         return self
 
 

--- a/tests/test_olefile.py
+++ b/tests/test_olefile.py
@@ -20,6 +20,11 @@ class TestOlefile(unittest.TestCase):
         is_ole = olefile.isOleFile(self.ole_file)
         self.assertTrue(is_ole)
 
+    def test_context_manager(self):
+        with olefile.OleFileIO(self.ole_file) as ole:
+            exists = ole.exists('worddocument')
+            self.assertTrue(exists)
+
     def test_exists_worddocument(self):
         ole = olefile.OleFileIO(self.ole_file)
         exists = ole.exists('worddocument')


### PR DESCRIPTION
This adds a context manager to OleFileIO enabling users to write

```
with olefile.OleFileIO('myfile') as ole:
    ...
```

and not having to worry about remembering to close the file.