### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 cache: pip
-sudo: false
 
 matrix:
   include:
@@ -10,7 +9,6 @@ matrix:
     - python: 3.6
     - python: 3.7
       dist: xenial
-      sudo: true
     - python: pypy
     - python: pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: pip
 matrix:
   include:
     - python: 2.7
-    - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ environment:
     - PYTHON: "C:/Python36"
     - PYTHON: "C:/Python35-x64"
     - PYTHON: "C:/Python35"
-    - PYTHON: "C:/Python34-x64"
-    - PYTHON: "C:/Python34"
 init:
   - "ECHO %PYTHON%"
   - ps: "ls C:/Python*"

--- a/doc/History.rst
+++ b/doc/History.rst
@@ -27,7 +27,7 @@ due to the maintenance of the olefile code in two repositories.
 Main improvements over the original version of OleFileIO in PIL:
 ----------------------------------------------------------------
 
--  Compatible with Python 3.4+ and 2.7+
+-  Compatible with Python 3.5+ and 2.7
 -  Many bug fixes
 -  Support for files larger than 6.8MB
 -  Support for 64 bits platforms and big-endian CPUs

--- a/doc/Install.rst
+++ b/doc/Install.rst
@@ -5,7 +5,7 @@ How to Download and Install olefile
 Pre-requisites
 --------------
 
-olefile requires Python 2.7 or 3.4+.
+olefile requires Python 2.7 or 3.5+.
 
 
 Download and Install

--- a/olefile/__init__.py
+++ b/olefile/__init__.py
@@ -4,7 +4,7 @@ olefile (formerly OleFileIO_PL)
 Module to read/write Microsoft OLE2 files (also called Structured Storage or
 Microsoft Compound Document File Format), such as Microsoft Office 97-2003
 documents, Image Composer and FlashPix files, Outlook messages, ...
-This version is compatible with Python 2.7 and 3.4+
+This version is compatible with Python 2.7 and 3.5+
 
 Project website: https://www.decalage.info/olefile
 

--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -4,7 +4,7 @@ olefile (formerly OleFileIO_PL)
 Module to read/write Microsoft OLE2 files (also called Structured Storage or
 Microsoft Compound Document File Format), such as Microsoft Office 97-2003
 documents, Image Composer and FlashPix files, Outlook messages, ...
-This version is compatible with Python 2.7 and 3.4+
+This version is compatible with Python 2.7 and 3.5+
 
 Project website: https://www.decalage.info/olefile
 
@@ -22,11 +22,11 @@ Copyright (c) 1995-2009 by Fredrik Lundh
 See source code and LICENSE.txt for information on usage and redistribution.
 """
 
-# Since OleFileIO_PL v0.45, only Python 2.7 and 3.4+ are supported
+# Since OleFileIO_PL v0.47, only Python 2.7 and 3.5+ are supported
 # This import enables print() as a function rather than a keyword
 # (main requirement to be compatible with Python 3.x)
 # The comment on the line below should be printed on Python 2.5 or older:
-from __future__ import print_function   # This version of olefile requires Python 2.7 or 3.4+.
+from __future__ import print_function   # This version of olefile requires Python 2.7 or 3.5+.
 
 
 #--- LICENSE ------------------------------------------------------------------

--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -522,11 +522,11 @@ class OleMetadata:
         print('Properties from SummaryInformation stream:')
         for prop in self.SUMMARY_ATTRIBS:
             value = getattr(self, prop)
-            print('- %s: %s' % (prop, repr(value)))
+            print('- {}: {}'.format(prop, repr(value)))
         print('Properties from DocumentSummaryInformation stream:')
         for prop in self.DOCSUM_ATTRIBS:
             value = getattr(self, prop)
-            print('- %s: %s' % (prop, repr(value)))
+            print('- {}: {}'.format(prop, repr(value)))
 
 
 #--- OleStream ---------------------------------------------------------------
@@ -1188,7 +1188,7 @@ class OleFileIO:
         header = self.fp.read(512)
 
         if len(header) != 512 or header[:8] != MAGIC:
-            log.debug('Magic = %r instead of %r' % (header[:8], MAGIC))
+            log.debug('Magic = {!r} instead of {!r}'.format(header[:8], MAGIC))
             self._raise_defect(DEFECT_FATAL, "not an OLE2 structured storage file")
 
         # [PL] header structure according to AAF specifications:
@@ -2137,7 +2137,7 @@ class OleFileIO:
             # catch exception while parsing property header, and only raise
             # a DEFECT_INCORRECT then return an empty dict, because this is not
             # a fatal error when parsing the whole file
-            msg = 'Error while parsing properties header in stream %s: %s' % (
+            msg = 'Error while parsing properties header in stream {}: {}'.format(
                 repr(streampath), exc)
             self._raise_defect(DEFECT_INCORRECT, msg, type(exc))
             return data
@@ -2292,7 +2292,7 @@ def main():
 
     (options, args) = parser.parse_args()
 
-    print('olefile version %s %s - https://www.decalage.info/en/olefile\n' % (__version__, __date__))
+    print('olefile version {} {} - https://www.decalage.info/en/olefile\n'.format(__version__, __date__))
 
     # Print help if no arguments are passed
     if len(args) == 0:
@@ -2362,7 +2362,7 @@ def main():
             print('Modification/Creation times of all directory entries:')
             for entry in ole.direntries:
                 if entry is not None:
-                    print('- %s: mtime=%s ctime=%s' % (entry.name,
+                    print('- {}: mtime={} ctime={}'.format(entry.name,
                         entry.getmtime(), entry.getctime()))
             print()
 
@@ -2387,7 +2387,7 @@ def main():
             print('\nNon-fatal issues raised during parsing:')
             if ole.parsing_issues:
                 for exctype, msg in ole.parsing_issues:
-                    print('- %s: %s' % (exctype.__name__, msg))
+                    print('- {}: {}'.format(exctype.__name__, msg))
             else:
                 print('None')
         except:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ classifiers = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
@@ -75,7 +74,7 @@ def main():
         download_url=download_url,
 #        data_files=data_files,
 #        scripts=scripts,
-        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     )
 
 

--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
 curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python34\Scripts\virtualenv.exe -p c:\pypy2-v5.9.0-win32\pypy.exe c:\vp\pypy2
+c:\Python37\Scripts\virtualenv.exe -p c:\pypy2-v5.9.0-win32\pypy.exe c:\vp\pypy2

--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-win32.zip
+curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-win32.zip
 7z x pypy2.zip -oc:\
-c:\Python37\Scripts\virtualenv.exe -p c:\pypy2-v5.9.0-win32\pypy.exe c:\vp\pypy2
+c:\Python37\Scripts\virtualenv.exe -p c:\pypy2.7-v7.1.1-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
Python 3.4 reached [EOL on 2019-03-16](https://devguide.python.org/#status-of-python-branches) and is no longer supported by the core Python team.

Pillow dropped support in the most recent 6.0.0 release: https://github.com/python-pillow/Pillow/pull/3596.

The tested PyPy version is also updated on AppVeyor.