### PR TITLE
Break when property offset exceeds stream

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -2172,6 +2172,9 @@ class OleFileIO:
         num_props = min(num_props, int(len(s) / 8))
         for i in iterrange(num_props):
             property_id = 0 # just in case of an exception
+            if 8+i*8 > len(s):
+                break
+
             try:
                 property_id = i32(s, 8+i*8)
                 offset = i32(s, 12+i*8)


### PR DESCRIPTION
When a file is corrupted or from untrusted source (possibly a malware), the number of property can be extremely large and exceed the longer of the stream.

Instead of looping over and over for unparsable properties, we should exit the loop early.


Sample that cause the issue:
https://www.virustotal.com/gui/file/250ff87ba85b2cb7bd04c9e4442eb08f70d5c1d555347c16addaa0d05bda8cb0/detection
https://app.any.run/tasks/f9e1d49a-5eec-4392-97b3-a109a2db8007/