### PR TITLE
Test Python 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - python: 3.6
     - python: 3.7
     - python: 3.8
+    - python: 3.9-dev
     - python: pypy
     - python: pypy3
 


### PR DESCRIPTION
Python 3.9.0 final is due out in October. The first release candidate is out, and it's strongly recommended to test third-party libraries on it, to both make sure the library is ready for 3.9, and to help test 3.9 itself.

https://www.python.org/dev/peps/pep-0596/