### PR TITLE
CI: Fix PyPy download link

### DIFF
--- a/winbuild/appveyor_install_pypy.cmd
+++ b/winbuild/appveyor_install_pypy.cmd
@@ -1,3 +1,3 @@
-curl -fsSL -o pypy2.zip https://bitbucket.org/pypy/pypy/downloads/pypy2.7-v7.1.1-win32.zip
+curl -fsSL -o pypy2.zip https://downloads.python.org/pypy/pypy2.7-v7.1.1-win32.zip
 7z x pypy2.zip -oc:\
 c:\Python37\Scripts\virtualenv.exe -p c:\pypy2.7-v7.1.1-win32\pypy.exe c:\vp\pypy2


### PR DESCRIPTION
This fixes the Windows PyPy build.

* Before: https://ci.appveyor.com/project/hugovk/olefile/builds/34763513

---

https://bitbucket.org/pypy/pypy/ now says:

> ### Repository unavailable
> Bitbucket no longer supports Mercurial repositories.

PyPy source and issues has moved to https://foss.heptapod.net/pypy/pypy

Downloads are now at downloads.python.org:

* https://www.pypy.org/download.html
* https://downloads.python.org/pypy/

