### PR TITLE
Update olefile.py

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -618,12 +618,16 @@ class OleStream(io.BytesIO):
         log.debug('nb_sectors = %d' % nb_sectors)
         # This number should (at least) be less than the total number of
         # sectors in the given FAT:
+        data = []
         if nb_sectors > len(fat):
             self.ole._raise_defect(DEFECT_INCORRECT, 'malformed OLE document, stream too large')
+            data = b"".join(data)
+            io.BytesIO.__init__(self, data)
+            return
         # optimization(?): data is first a list of strings, and join() is called
         # at the end to concatenate all in one string.
         # (this may not be really useful with recent Python versions)
-        data = []
+
         # if size is zero, then first sector index should be ENDOFCHAIN:
         if size == 0 and sect != ENDOFCHAIN:
             log.debug('size == 0 and sect != ENDOFCHAIN:')


### PR DESCRIPTION
Fix when scan incorrect doc cause memory  crash

When I use mraptor scan a incorrect doc file, that caused memory crash. I followed this code run, find that problem caused in olefiel.py.
crash doc file :[https://github.com/BootKitS/hexo/blob/master/file/123.doc](url)

Issus：

**Affected tool:**
mraptor 

**Describe the bug**
 When scan incorrect doc cause memory  crash

**File sample to reproduce the bug**
https://github.com/BootKitS/hexo/blob/master/file/123.doc

**How To Reproduce the bug**

~~~
python mraptor.py 123.doc
~~~



**Expected behavior**
Return result code and exit  program.

**Console output / Screenshots**
![1](https://user-images.githubusercontent.com/10338898/96335928-92e88d00-10ae-11eb-9f04-bf25d507c9ed.png)
![2](https://user-images.githubusercontent.com/10338898/96335929-9419ba00-10ae-11eb-8242-e5bf4a6be754.png)
![3](https://user-images.githubusercontent.com/10338898/96335931-95e37d80-10ae-11eb-9036-b027213df7e7.png)


Version information:**

- OS: Windows 10
- OS version: /64 bits
- Python version: 3.7.5 64bit
- oletools version: **v0.56**

**Additional context**

Read Much incorrect sector and no exception caught
