### PR TITLE
Fix incorrect parsing of the size of the VT_LPWSTR property.

### DIFF
--- a/olefile/olefile.py
+++ b/olefile/olefile.py
@@ -2288,7 +2288,7 @@ class OleFileIO:
                 # see https://msdn.microsoft.com/en-us/library/dd942313.aspx
                 # "the string should NOT contain embedded or additional trailing
                 # null characters."
-                count = i32(s, offset+4)
+                count = i32(s, offset)
                 value = self._decode_utf16_str(s[offset+4:offset+4+count*2])
                 size = 4 + count * 2
             elif property_type == VT_FILETIME:


### PR DESCRIPTION
I identified a bug in the code when parsing one of the samples that we use in tests. It was introduced in the latest `0.47` release. 
I compared changes and run some debug sessions and successfully identified a small piece of code that caused the issue.